### PR TITLE
add support for Minimum fuel

### DIFF
--- a/app/fuelCalculatorByLaps.js
+++ b/app/fuelCalculatorByLaps.js
@@ -25,16 +25,29 @@ angular.module("FuelCalculators",[])
         }
       };
 
-      this.doLap = function () {
+      this.completeLap = function() {
         this.lapsRemaining--;
         this.lapNumber++;
+        this.consumeFuel();
+      }
+
+      this.consumeFuel = function() {
         this.fuelTank -= this.fuelTankAttributes.consumption;
-        if (this.fuelTank < this.fuelTankAttributes.consumption && this.lapsRemaining > 0) {
+      }
+
+      this.pitStopStrategyDecision = function () {
+        // we need to make sure that we would consume fuel below minimumFuel
+        // when the engine starts coughing
+        var wouldBeBelowMinimum = (this.fuelTank - this.fuelTankAttributes.consumption) < this.fuelTankAttributes.minimumFuel;
+        if (wouldBeBelowMinimum && this.lapsRemaining > 0) {
           this.pitstop();
         }
+      };
+      this.doLap = function () {
+        this.completeLap();
+        this.pitStopStrategyDecision();
         this.emitLap();
       };
-
       this.raceCompleted = function () {
         return this.lapsRemaining === 0;
       };

--- a/index.html
+++ b/index.html
@@ -99,6 +99,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
                     consumption: undefined,
                     maximumFuel: undefined,
                     initialFuel: undefined,
+                    minimumFuel: 0,
                     tankpercentstart: 60
                   };
                 }

--- a/index.html
+++ b/index.html
@@ -99,8 +99,12 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
                     consumption: undefined,
                     maximumFuel: undefined,
                     initialFuel: undefined,
-                    minimumFuel: 0,
-                    tankpercentstart: 60
+                    minimumFuel: undefined,
+                    tankpercentstart: 60,
+
+                    validTank: function () {
+                      return this.maximumFuel > 0 && this.minimumFuel > 0 && this.consumption > 0;
+                    }
                   };
                 }
 
@@ -188,7 +192,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 
                 $scope.recalculateLapData = function() {
                   $scope.clearTableData();
-                  if($scope.lapsinsession && $scope.fuelTank.consumption>0) {
+                  if($scope.lapsinsession && $scope.fuelTank.validTank()) {
                     fc = new ByLap.FuelCalculatorByLap($scope.fuelTank, $scope.lapsinsession(), lapDataHandler, pitStopHandler);
                     fc.startRace();
                   }
@@ -301,53 +305,67 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
         <div class="panel panel-default">
             <div class="panel-body">
 
-                <form class="form-horizontal">
-                    <ul class="nav nav-tabs">
-                        <li role="presentation" ng-class="{active: byTimePresentation}"><a id="byTimeTab" ng-click="changeCalculationMode(true)">Time</a></li>
-                        <li role="presentation" ng-class="{active: !byTimePresentation}"><a id="byLapTab" ng-click="changeCalculationMode(false)">Lap</a></li>
-                    </ul>
-                    <div class="form-group">
-                      <label class="col-sm-4 control-label">Tank Size</label>
-                      <div class="col-sm-8">
-                        <input class="form-control" type="number" ng-model="fuelTank.maximumFuel" placeholder="Maximum Tank Size" ng-change="recalculateLapData()">
-                      </div>
+              <form class="form-horizontal">
+                <ul class="nav nav-tabs">
+                  <li role="presentation" ng-class="{active: byTimePresentation}"><a id="byTimeTab"
+                                                                                     ng-click="changeCalculationMode(true)">Time</a>
+                  </li>
+                  <li role="presentation" ng-class="{active: !byTimePresentation}"><a id="byLapTab"
+                                                                                      ng-click="changeCalculationMode(false)">Lap</a>
+                  </li>
+                </ul>
+                <div class="form-group">
+                  <div class="form-group">
+                    <label class="col-sm-4 control-label">Fuel Tank Attributes</label>
+                    <div class="col-sm-4">
+                      <input class="form-control" type="number" ng-model="fuelTank.maximumFuel"
+                           placeholder="Tank Size" ng-change="recalculateLapData()" required>
                     </div>
+                    <div class="col-sm-4">
+                      <input class="form-control" type="number" ng-model="fuelTank.minimumFuel"
+                           placeholder="Minimum fuel" ng-change="recalculateLapData()" required>
+                    </div>
+                  </div>
+                  <div class="form-group">
+                    <label class="col-sm-4 control-label">Fuel consumption / lap</label>
+                    <div class="col-sm-8">
+                      <input class="form-control" id="consumption" ng-model="fuelTank.consumption"
+                             ng-change="recalculateLapData()"
+                             placeholder="Liters, Gallons, Kgs, etc">
+                    </div>
+                  </div>
 
-                    <div class="form-group" ng-show="!byTimePresentation">
-                        <label class="col-sm-4 control-label">Laps</label>
-                        <div class="col-sm-8">
-                            <input class="form-control" type="number" ng-model="numberOfLaps" placeholder="Number Of Laps" ng-change="recalculateLapData()">
-                        </div>
+                  <div class="form-group" ng-show="!byTimePresentation">
+                    <label class="col-sm-4 control-label">Laps</label>
+                    <div class="col-sm-8">
+                      <input class="form-control" type="number" ng-model="numberOfLaps" placeholder="Number of Laps"
+                             ng-change="recalculateLapData()">
                     </div>
-                    <div class="form-group" ng-show="byTimePresentation">
-                        <label class="col-sm-4 control-label">Session Time</label>
-                        <div class="col-sm-8">
-                            <input class="form-control" type="number" ng-model="sessiontimeminutes" placeholder="Session time">
-                        </div>
+                  </div>
+                  <div class="form-group" ng-show="byTimePresentation">
+                    <label class="col-sm-4 control-label">Session Time</label>
+                    <div class="col-sm-8">
+                      <input class="form-control" type="number" ng-model="sessiontimeminutes"
+                             placeholder="Session time">
                     </div>
-                    <div class="form-group" ng-show="byTimePresentation">
-                        <label class="col-sm-4 control-label">Lap Time</label>
-                        <div class="col-sm-4">
-                            <input class="form-control" type="number" ng-model="lapminutes" placeholder="Minutes">
-                        </div>
-                        <div class="col-sm-4">
-                            <input class="form-control" type="number" ng-model="lapseconds" placeholder="Seconds">
-                        </div>
+                  </div>
+                  <div class="form-group" ng-show="byTimePresentation">
+                    <label class="col-sm-4 control-label">Lap Time</label>
+                    <div class="col-sm-4">
+                      <input class="form-control" type="number" ng-model="lapminutes" placeholder="Minutes">
                     </div>
-                    <div class="form-group" ng-show="byTimePresentation">
-                        <div class="col-sm-12">
-                            <small>Lap duration in seconds {{singlelaptime()}}</small>
-                        </div>
+                    <div class="col-sm-4">
+                      <input class="form-control" type="number" ng-model="lapseconds" placeholder="Seconds">
                     </div>
+                  </div>
+                  <div class="form-group" ng-show="byTimePresentation">
+                    <div class="col-sm-12">
+                      <small>Lap duration in seconds {{singlelaptime()}}</small>
+                    </div>
+                  </div>
 
-                    <div class="form-group">
-                        <label class="col-sm-4 control-label">Fuel consumption per lap</label>
-                        <div class="col-sm-8">
-                            <input class="form-control" id="consumption" ng-model="fuelTank.consumption" ng-change="recalculateLapData()"
-                                   placeholder="Liters, Gallons, Kgs, etc">
-                        </div>
-                    </div>
-                </form>
+                </div>
+              </form>
             </div>
             <div class="panel-footer" ng-show="validData()">
                 <p class="lead">You need {{fuelneededinsession() | number : 3}} units of fuel</p>

--- a/protractor/fuelcalculator-spec.js
+++ b/protractor/fuelcalculator-spec.js
@@ -9,6 +9,7 @@ describe('FuelCalculator By Lap', function() {
     element(by.model('fuelTank.maximumFuel')).clear().sendKeys('3');
     element(by.model('numberOfLaps')).sendKeys('20');
     element(by.model('fuelTank.consumption')).sendKeys('0.605');
+    element(by.model('fuelTank.minimumFuel')).sendKeys('0.3');
 
 
     // really need to use the gridTest but not sure how to include that library in there yett..
@@ -35,6 +36,8 @@ describe('FuelCalculator By Time', function() {
     element(by.model('lapseconds')).sendKeys('47');
     element(by.model('fuelTank.consumption')).sendKeys('2.69');
     element(by.model('fuelTank.maximumFuel')).clear().sendKeys('90');
+    element(by.model('fuelTank.minimumFuel')).sendKeys('0.3');
+
 
 
     // really need to use the gridTest but not sure how to include that library in there yett..

--- a/test/fuelCalculatorByLaps.test.js
+++ b/test/fuelCalculatorByLaps.test.js
@@ -9,7 +9,7 @@ describe('Calculator', function () {
 
   beforeEach(inject(function (_ByLap_) {
     $ByLap = _ByLap_;
-    fuelTankAttributes = {maximumFuel: 9, initialFuel: 9, consumption:  0.605};
+    fuelTankAttributes = {maximumFuel: 9, initialFuel: 9, minimumFuel:0, consumption:  0.605};
   }));
 
   it('should handle no lapDapHandler correctly', function () {
@@ -34,7 +34,7 @@ describe('Calculator', function () {
   it('should compute correct number of pitstops', function () {
     var pitStopHandler = {};
     pitStopHandler.handlePitStop = jasmine.createSpy("handlePitStop");
-    var fuelTankAttributes = {maximumFuel: 9, initialFuel: 9, consumption:  2};
+    var fuelTankAttributes = {maximumFuel: 9, initialFuel: 9, minimumFuel: 0, consumption:  2};
     var fc = new $ByLap.FuelCalculatorByLap(fuelTankAttributes, expectedLaps, undefined, pitStopHandler);
     fc.startRace();
     expect(pitStopHandler.handlePitStop.calls.count()).toBe(4);
@@ -43,7 +43,7 @@ describe('Calculator', function () {
   it('Pitstop event should indicate how much fuel was put in', function () {
     var pitStopHandler = {};
     pitStopHandler.handlePitStop = jasmine.createSpy("handlePitStop");
-    var fc = new $ByLap.FuelCalculatorByLap({maximumFuel: 10, consumption:2}, 10, undefined, pitStopHandler);
+    var fc = new $ByLap.FuelCalculatorByLap({maximumFuel: 10, minimumFuel:0, consumption:2}, 10, undefined, pitStopHandler);
     fc.startRace();
     expect(pitStopHandler.handlePitStop.calls.first()).toEqual({object: pitStopHandler, args: [{lapNumber:5, fuelState:0, fuelAdded:10, fuelStateOnExit:10}], returnValue: undefined});
 
@@ -83,5 +83,18 @@ describe('Calculator', function () {
     fc.startRace();
     expect(pitStopHandler.numPitstops).toBe(0);
   });
+
+  it('should not attempt to cough across the line gasping for fuel', function () {
+    var pitStopHandler = {numPitstops: 0, fuelAdded: 0};
+    pitStopHandler.handlePitStop = function (pitStopData) {
+      this.fuelAdded = pitStopData.fuelAdded;
+      this.numPitstops++;
+    }
+    var fc = new $ByLap.FuelCalculatorByLap({maximumFuel: 5, minimumFuel:0.3, consumption: 1}, 5, undefined, pitStopHandler);
+    fc.startRace();
+    expect(pitStopHandler.numPitstops).toBe(1);
+  });
+
+
 
 });


### PR DESCRIPTION
Previously the Calculator presumed that it could run the tank dry, potentially running full steam across the line just as the tank went empty.

In reality in simulators like iRacing there is a minimum fuel point where the engine starts to cough, and your speed drops.  Ideally one would want to avoid that, and so for calculation purposes we need to factor in this minimum fuel point.  It will be different for every car, just like the maximum is.

Would close Issue #11 