### PR TITLE
Pitstop time penalty

### DIFF
--- a/app/fuelCalculatorByLaps.js
+++ b/app/fuelCalculatorByLaps.js
@@ -6,7 +6,7 @@ angular.module("FuelCalculators",[])
 
     this.FuelCalculatorByLap = function (fuelTankAttributes, numLaps, raceParameters, lapDataHandler, pitStopHandler) {
       this.fuelTankAttributes = fuelTankAttributes;
-      this.fuelTank = fuelTankAttributes.initialFuel ? fuelTankAttributes.initialFuel : fuelTankAttributes.maximumFuel;
+      this.fuelTank = fuelTankAttributes.initialFuel === undefined ? fuelTankAttributes.maximumFuel : fuelTankAttributes.initialFuel;
       this.raceParameters = raceParameters;
       this.raceTime = 0;
 
@@ -65,6 +65,10 @@ angular.module("FuelCalculators",[])
         }
         this.raceTime += raceParameters.pitStopTimePenalty;
         this.fuelTank = newFuelTank;
+      };
+
+      this.canStartRace = function () {
+        return this.fuelTank > 0 && this.fuelTankAttributes.consumption > 0;
       };
 
       this.startRace = function () {

--- a/app/fuelCalculatorByLaps.js
+++ b/app/fuelCalculatorByLaps.js
@@ -4,13 +4,13 @@ angular.module("FuelCalculators",[])
   .service("ByLap", function () {
 
 
-    this.FuelCalculatorByLap = function (fuelTankAttributes, numLaps, raceParameters, lapDataHandler, pitStopHandler) {
+    this.FuelCalculatorByLap = function (fuelTankAttributes, raceParameters, lapDataHandler, pitStopHandler) {
       this.fuelTankAttributes = fuelTankAttributes;
       this.fuelTank = fuelTankAttributes.initialFuel === undefined ? fuelTankAttributes.maximumFuel : fuelTankAttributes.initialFuel;
       this.raceParameters = raceParameters;
       this.raceTime = 0;
 
-      this.lapsRemaining = numLaps;
+      this.lapsRemaining = raceParameters.numLaps;
       this.lapNumber = 0;
       this.lapDataHandler = lapDataHandler;
       this.pitStopHandler = pitStopHandler;

--- a/app/fuelCalculatorByLaps.js
+++ b/app/fuelCalculatorByLaps.js
@@ -68,7 +68,7 @@ angular.module("FuelCalculators",[])
       };
 
       this.canStartRace = function () {
-        return this.fuelTank > 0 && this.fuelTankAttributes.consumption > 0;
+        return this.fuelTank > 0 && this.fuelTankAttributes.consumption > 0 && this.lapsRemaining>0;
       };
 
       this.startRace = function () {

--- a/app/fuelCalculatorByLaps.js
+++ b/app/fuelCalculatorByLaps.js
@@ -102,13 +102,10 @@ angular.module("FuelCalculators",[])
           }
           return {
             chequeredFlag: this.lapsRemaining===0,
-            lapsCompleted: this.lapNumber
+            lapsCompleted: this.lapNumber,
+            totalRaceTime: this.raceTime
           };
         }
-      };
-
-      this.totalRaceTime = function () {
-        return this.raceTime;
       };
     };
   });

--- a/app/fuelCalculatorByLaps.js
+++ b/app/fuelCalculatorByLaps.js
@@ -4,9 +4,11 @@ angular.module("FuelCalculators",[])
   .service("ByLap", function () {
 
 
-    this.FuelCalculatorByLap = function (fuelTankAttributes, numLaps, lapDataHandler, pitStopHandler) {
+    this.FuelCalculatorByLap = function (fuelTankAttributes, numLaps, raceParameters, lapDataHandler, pitStopHandler) {
       this.fuelTankAttributes = fuelTankAttributes;
       this.fuelTank = fuelTankAttributes.initialFuel ? fuelTankAttributes.initialFuel : fuelTankAttributes.maximumFuel;
+      this.raceParameters = raceParameters;
+      this.raceTime = 0;
 
       this.lapsRemaining = numLaps;
       this.lapNumber = 0;
@@ -32,6 +34,7 @@ angular.module("FuelCalculators",[])
       }
 
       this.consumeFuel = function() {
+        this.raceTime += this.raceParameters.expectedLapTime;
         this.fuelTank -= this.fuelTankAttributes.consumption;
       }
 
@@ -60,6 +63,7 @@ angular.module("FuelCalculators",[])
           lapData.fuelStateOnExit = newFuelTank;
           this.pitStopHandler.handlePitStop(lapData);
         }
+        this.raceTime += raceParameters.pitStopTimePenalty;
         this.fuelTank = newFuelTank;
       };
 
@@ -70,6 +74,10 @@ angular.module("FuelCalculators",[])
             this.doLap();
           }
         }
+      };
+
+      this.totalRaceTime = function () {
+        return this.raceTime;
       };
     };
   });

--- a/app/fuelCalculatorByLaps.js
+++ b/app/fuelCalculatorByLaps.js
@@ -12,6 +12,7 @@ angular.module("FuelCalculators",[])
       this.pitstopStrategy = {
         consumption: this.fuelTankAttributes.consumption,
         minimumFuel: this.fuelTankAttributes.minimumFuel,
+        maximumFuel: this.fuelTankAttributes.maximumFuel,
         shouldPit: function (lapData) {
           // we need to make sure that we would consume fuel below minimumFuel
           // when the engine starts coughing
@@ -20,7 +21,9 @@ angular.module("FuelCalculators",[])
             return true;
           }
           return false;
-
+        },
+        fuelLevelToFillTo: function (lapData) {
+          return this.maximumFuel;
         }
       };
       this.raceTime = 0;
@@ -55,8 +58,9 @@ angular.module("FuelCalculators",[])
       }
 
       this.pitStopStrategyDecision = function () {
-        if(this.pitstopStrategy.shouldPit(this.lapData())) {
-          this.pitstop();
+        var lapData = this.lapData();
+        if(this.pitstopStrategy.shouldPit(lapData)) {
+          this.pitstop(this.pitstopStrategy.fuelLevelToFillTo(lapData));
         }
       };
       this.doLap = function () {
@@ -68,11 +72,11 @@ angular.module("FuelCalculators",[])
         return this.lapsRemaining === 0;
       };
 
-      this.pitstop = function () {
-        var newFuelTank = this.fuelTankAttributes.maximumFuel;
+      this.pitstop = function (fuelLevelToFillTo) {
+        var newFuelTank = fuelLevelToFillTo;
         if(this.pitStopHandler && this.pitStopHandler.handlePitStop){
           var lapData = this.lapData();
-          lapData.fuelAdded = this.fuelTankAttributes.maximumFuel - this.fuelTank;
+          lapData.fuelAdded = fuelLevelToFillTo - this.fuelTank;
           lapData.fuelStateOnExit = newFuelTank;
           this.pitStopHandler.handlePitStop(lapData);
         }

--- a/app/fuelCalculatorByLaps.js
+++ b/app/fuelCalculatorByLaps.js
@@ -3,16 +3,11 @@
 angular.module("FuelCalculators",[])
   .service("ByLap", function () {
 
-
-    this.FuelCalculatorByLap = function (fuelTankAttributes, raceParameters, lapDataHandler, pitStopHandler) {
-      this.fuelTankAttributes = fuelTankAttributes;
-      this.fuelTank = fuelTankAttributes.initialFuel === undefined ? fuelTankAttributes.maximumFuel : fuelTankAttributes.initialFuel;
-      this.raceParameters = raceParameters;
-
-      this.pitstopStrategy = {
-        consumption: this.fuelTankAttributes.consumption,
-        minimumFuel: this.fuelTankAttributes.minimumFuel,
-        maximumFuel: this.fuelTankAttributes.maximumFuel,
+    var SimplePitStopStrategy = function (consumption, minimumFuel, maximumFuel) {
+      return {
+        consumption: consumption,
+        minimumFuel: minimumFuel,
+        maximumFuel: maximumFuel,
         shouldPit: function (lapData) {
           // we need to make sure that we would consume fuel below minimumFuel
           // when the engine starts coughing
@@ -25,7 +20,15 @@ angular.module("FuelCalculators",[])
         fuelLevelToFillTo: function (lapData) {
           return this.maximumFuel;
         }
-      };
+      }
+    };
+
+    this.FuelCalculatorByLap = function (fuelTankAttributes, raceParameters, lapDataHandler, pitStopHandler) {
+      this.fuelTankAttributes = fuelTankAttributes;
+      this.fuelTank = fuelTankAttributes.initialFuel === undefined ? fuelTankAttributes.maximumFuel : fuelTankAttributes.initialFuel;
+      this.raceParameters = raceParameters;
+
+      this.pitstopStrategy = SimplePitStopStrategy(fuelTankAttributes.consumption, fuelTankAttributes.minimumFuel, fuelTankAttributes.maximumFuel);
       this.raceTime = 0;
 
       this.lapsRemaining = raceParameters.numLaps;

--- a/app/fuelCalculatorByLaps.js
+++ b/app/fuelCalculatorByLaps.js
@@ -20,7 +20,7 @@ angular.module("FuelCalculators",[])
         fuelLevelToFillTo: function (lapData) {
           return this.maximumFuel;
         }
-      }
+      };
     };
 
     this.FuelCalculatorByLap = function (fuelTankAttributes, raceParameters, lapDataHandler, pitStopHandler) {
@@ -28,7 +28,7 @@ angular.module("FuelCalculators",[])
       this.fuelTank = fuelTankAttributes.initialFuel === undefined ? fuelTankAttributes.maximumFuel : fuelTankAttributes.initialFuel;
       this.raceParameters = raceParameters;
 
-      this.pitstopStrategy = SimplePitStopStrategy(fuelTankAttributes.consumption, fuelTankAttributes.minimumFuel, fuelTankAttributes.maximumFuel);
+      this.pitstopStrategy = raceParameters.pitStopStrategy || SimplePitStopStrategy(fuelTankAttributes.consumption, fuelTankAttributes.minimumFuel, fuelTankAttributes.maximumFuel);
       this.raceTime = 0;
 
       this.lapsRemaining = raceParameters.numLaps;
@@ -71,8 +71,11 @@ angular.module("FuelCalculators",[])
         this.pitStopStrategyDecision();
         this.emitLap();
       };
+
       this.raceCompleted = function () {
-        return this.lapsRemaining === 0;
+        // race is over if there are no more laps to do, or there is not enough fuel in the tank
+        // to complete a lap
+        return this.lapsRemaining === 0 || this.fuelTank < (this.fuelTankAttributes.consumption+this.fuelTankAttributes.minimumFuel);
       };
 
       this.pitstop = function (fuelLevelToFillTo) {
@@ -97,6 +100,10 @@ angular.module("FuelCalculators",[])
           while (!this.raceCompleted()) {
             this.doLap();
           }
+          return {
+            chequeredFlag: this.lapsRemaining===0,
+            lapsCompleted: this.lapNumber
+          };
         }
       };
 

--- a/app/services/fuelTank.js
+++ b/app/services/fuelTank.js
@@ -1,0 +1,20 @@
+"use strict"
+
+angular.module('FuelTank', [])
+  .factory('FuelTankFactory', function () {
+    return {
+      newFuelTank: function () {
+        return {
+          consumption: undefined,
+          maximumFuel: undefined,
+          initialFuel: undefined,
+          minimumFuel: undefined,
+          tankpercentstart: 60,
+
+          validTank: function () {
+            return this.maximumFuel > 0 && this.minimumFuel >= 0 && this.consumption > 0;
+          }
+        };
+      }
+    };
+  });

--- a/index.html
+++ b/index.html
@@ -197,7 +197,11 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
                 $scope.recalculateLapData = function() {
                   $scope.clearTableData();
                   if($scope.lapsinsession()>0 && $scope.fuelTank.validTank()) {
-                    fc = new ByLap.FuelCalculatorByLap($scope.fuelTank, $scope.lapsinsession(), lapDataHandler, pitStopHandler);
+                    var raceParameters = {
+                      expectedLapTime: $scope.laptimeInSeconds,
+                      numLaps: $scope.lapsinsession()
+                    }
+                    fc = new ByLap.FuelCalculatorByLap($scope.fuelTank, raceParameters, lapDataHandler, pitStopHandler);
                     fc.startRace();
                   }
                   if($scope.validData()){

--- a/index.html
+++ b/index.html
@@ -207,7 +207,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
                   $scope.lapminutes = null;
                   $scope.lapseconds = null;
                   $scope.numberOfLaps = null;
-                  $scope.fuelTank =  FuelTank();
+                  $scope.fuelTank =  FuelTankFactory.newFuelTank();
                 };
 
                 $scope.changeCalculationMode = function(value){

--- a/index.html
+++ b/index.html
@@ -36,6 +36,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   <link rel="styleSheet" href="node_modules/angular-ui-grid/ui-grid.min.css"/>
 
   <script src="app/fuelCalculatorByLaps.js"></script>
+  <script src="app/services/fuelTank.js"></script>
 
 
 <style type="text/css">
@@ -89,25 +90,12 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   ga('create', 'UA-96339081-1', 'auto');
   ga('send', 'pageview');
 
-  angular.module("CalcApp", ['ui.bootstrap','FuelCalculators', 'ui.grid','chart.js', 'angularValidator'])
-    .controller("CalcCtrl", ['$scope','ByLap', 'uiGridConstants', function ($scope, ByLap, uiGridConstants) {
+  angular.module("CalcApp", ['ui.bootstrap','FuelCalculators','FuelTank', 'ui.grid','chart.js', 'angularValidator'])
+    .controller("CalcCtrl", ['$scope','ByLap', 'FuelTankFactory','uiGridConstants', function ($scope, ByLap, FuelTankFactory, uiGridConstants) {
 
-                // TODO this will need to be shared somewhere..
-                function FuelTank() {
-                  return {
-                    consumption: undefined,
-                    maximumFuel: undefined,
-                    initialFuel: undefined,
-                    minimumFuel: undefined,
-                    tankpercentstart: 60,
 
-                    validTank: function () {
-                      return this.maximumFuel > 0 && this.minimumFuel>=0 && this.consumption > 0;
-                    }
-                  };
-                }
 
-                $scope.fuelTank = new FuelTank();
+                $scope.fuelTank = FuelTankFactory.newFuelTank();
 
                 $scope.laptime = "";
 
@@ -219,7 +207,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
                   $scope.lapminutes = null;
                   $scope.lapseconds = null;
                   $scope.numberOfLaps = null;
-                  $scope.fuelTank = new FuelTank();
+                  $scope.fuelTank =  FuelTank();
                 };
 
                 $scope.changeCalculationMode = function(value){

--- a/protractor/fuelcalculator-spec.js
+++ b/protractor/fuelcalculator-spec.js
@@ -48,6 +48,30 @@ describe('FuelCalculator By Time', function() {
     expect(element(by.binding('lapsinsession')).getText()).toBe('Your race should be 15 laps');
     expect(element(by.binding('fuelneededinsession')).getText()).toBe('You need 40.350 units of fuel');
   });
+})
+
+describe('Tab Switching', function() {
+  it('It should clear the form when switching tabs', function() {
+    browser.get('http://localhost:8080/');
+
+    element(by.id('byTimeTab')).click();
+
+    element(by.model('sessiontimeminutes')).sendKeys('40');
+    element(by.model('laptime')).sendKeys('2:47');
+    element(by.model('fuelTank.consumption')).sendKeys('2.69');
+    element(by.model('fuelTank.maximumFuel')).clear().sendKeys('90');
+    element(by.model('fuelTank.minimumFuel')).sendKeys('0.3');
+
+
+    element(by.id('byLapTab')).click();
+
+    var rows = element(by.id('pitStopGrid')).element( by.css('.ui-grid-render-container-body')).all( by.repeater('(rowRenderIndex, row) in rowContainer.renderedRows track by $index') );
+    expect(rows.count()).toEqual(0);
+
+    expect(element(by.model('fuelTank.consumption')).getText()).toBe('');
+    expect(element(by.model('fuelTank.minimumFuel')).getText()).toBe('');
+    expect(element(by.model('fuelTank.maximumFuel')).getText()).toBe('');
+  });
 });
 
 

--- a/test/fuelCalculatorByLaps.test.js
+++ b/test/fuelCalculatorByLaps.test.js
@@ -4,6 +4,7 @@ describe('Calculator', function () {
   var $ByLap;
   var fuelTankAttributes;
   var expectedLaps = 20;
+  var pitStopParameters = {expectedLapTime:107, pitStopTimePenalty:0};
 
   beforeEach(module("FuelCalculators"));
 
@@ -14,19 +15,19 @@ describe('Calculator', function () {
 
   it('should handle no lapDapHandler correctly', function () {
 
-    var fc = new $ByLap.FuelCalculatorByLap(fuelTankAttributes, expectedLaps, undefined, {});
+    var fc = new $ByLap.FuelCalculatorByLap(fuelTankAttributes, expectedLaps, pitStopParameters, undefined, {});
     fc.startRace();
   });
 
   it('should handle no pitStopHandler correctly', function () {
-    var fc = new $ByLap.FuelCalculatorByLap(fuelTankAttributes, expectedLaps, {}, undefined);
+    var fc = new $ByLap.FuelCalculatorByLap(fuelTankAttributes, expectedLaps, pitStopParameters, {}, undefined);
     fc.startRace();
   });
 
   it('should compute correct number of laps', function () {
     var lapDataHandler = {};
     lapDataHandler.handleData = jasmine.createSpy("handleData");
-    var fc = new $ByLap.FuelCalculatorByLap(fuelTankAttributes, expectedLaps, lapDataHandler, undefined);
+    var fc = new $ByLap.FuelCalculatorByLap(fuelTankAttributes, expectedLaps, pitStopParameters, lapDataHandler, undefined);
     fc.startRace();
     expect(lapDataHandler.handleData.calls.count()).toBe(21);
   });
@@ -35,7 +36,7 @@ describe('Calculator', function () {
     var pitStopHandler = {};
     pitStopHandler.handlePitStop = jasmine.createSpy("handlePitStop");
     var fuelTankAttributes = {maximumFuel: 9, initialFuel: 9, minimumFuel: 0, consumption:  2};
-    var fc = new $ByLap.FuelCalculatorByLap(fuelTankAttributes, expectedLaps, undefined, pitStopHandler);
+    var fc = new $ByLap.FuelCalculatorByLap(fuelTankAttributes, expectedLaps, pitStopParameters, undefined, pitStopHandler);
     fc.startRace();
     expect(pitStopHandler.handlePitStop.calls.count()).toBe(4);
   });
@@ -43,7 +44,7 @@ describe('Calculator', function () {
   it('Pitstop event should indicate how much fuel was put in', function () {
     var pitStopHandler = {};
     pitStopHandler.handlePitStop = jasmine.createSpy("handlePitStop");
-    var fc = new $ByLap.FuelCalculatorByLap({maximumFuel: 10, minimumFuel:0, consumption:2}, 10, undefined, pitStopHandler);
+    var fc = new $ByLap.FuelCalculatorByLap({maximumFuel: 10, minimumFuel:0, consumption:2}, 10, pitStopParameters, undefined, pitStopHandler);
     fc.startRace();
     expect(pitStopHandler.handlePitStop.calls.first()).toEqual({object: pitStopHandler, args: [{lapNumber:5, fuelState:0, fuelAdded:10, fuelStateOnExit:10}], returnValue: undefined});
 
@@ -52,7 +53,7 @@ describe('Calculator', function () {
   it('should not run any laps with 0 fuel tank consumption', function () {
     var lapDataHandler = {};
     lapDataHandler.handleData = jasmine.createSpy("handleData");
-    var fc = new $ByLap.FuelCalculatorByLap(fuelTankAttributes, expectedLaps, 0, lapDataHandler, undefined);
+    var fc = new $ByLap.FuelCalculatorByLap(fuelTankAttributes, expectedLaps, 0, pitStopParameters, lapDataHandler, undefined);
     fc.startRace();
     expect(lapDataHandler.handleData.calls.count()).toBe(0);
   });
@@ -60,7 +61,7 @@ describe('Calculator', function () {
   it('should not run any laps with 0 expectedLaps', function () {
     var lapDataHandler = {};
     lapDataHandler.handleData = jasmine.createSpy("handleData");
-    var fc = new $ByLap.FuelCalculatorByLap(fuelTankAttributes, 0, lapDataHandler, undefined);
+    var fc = new $ByLap.FuelCalculatorByLap(fuelTankAttributes, 0, pitStopParameters, lapDataHandler, undefined);
     fc.startRace();
     expect(lapDataHandler.handleData.calls.count()).toBe(0);
   });
@@ -68,7 +69,7 @@ describe('Calculator', function () {
   it('should not suggest to pit on the final lap...', function () {
     var pitStopHandler = {};
     pitStopHandler.handlePitStop = jasmine.createSpy("handlePitStop");
-    var fc = new $ByLap.FuelCalculatorByLap({maximumFuel: 9.7, consumption: 0.605}, 16, undefined, pitStopHandler);
+    var fc = new $ByLap.FuelCalculatorByLap({maximumFuel: 9.7, consumption: 0.605}, 16, pitStopParameters, undefined, pitStopHandler);
     fc.startRace();
     expect(pitStopHandler.handlePitStop.calls.count()).toBe(0);
   });
@@ -79,7 +80,7 @@ describe('Calculator', function () {
       this.fuelAdded = pitStopData.fuelAdded;
       this.numPitstops++;
     }
-    var fc = new $ByLap.FuelCalculatorByLap({maximumFuel: 9.7, consumption: 0.605}, 16, undefined, pitStopHandler);
+    var fc = new $ByLap.FuelCalculatorByLap({maximumFuel: 9.7, consumption: 0.605}, 16, pitStopParameters, undefined, pitStopHandler);
     fc.startRace();
     expect(pitStopHandler.numPitstops).toBe(0);
   });

--- a/test/fuelCalculatorByLaps.test.js
+++ b/test/fuelCalculatorByLaps.test.js
@@ -46,7 +46,7 @@ describe('Calculator', function () {
     pitStopHandler.handlePitStop = jasmine.createSpy("handlePitStop");
     var fc = new $ByLap.FuelCalculatorByLap({maximumFuel: 10, minimumFuel:0, consumption:2}, raceParameters, undefined, pitStopHandler);
     fc.startRace();
-    expect(pitStopHandler.handlePitStop.calls.first()).toEqual({object: pitStopHandler, args: [{lapNumber:5, fuelState:0, fuelAdded:10, fuelStateOnExit:10}], returnValue: undefined});
+    expect(pitStopHandler.handlePitStop.calls.first()).toEqual({object: pitStopHandler, args: [{lapNumber:5, fuelState:0, lapsRemaining:15, fuelAdded:10, fuelStateOnExit:10}], returnValue: undefined});
 
   });
 

--- a/test/fuelCalculatorByLaps.test.js
+++ b/test/fuelCalculatorByLaps.test.js
@@ -24,6 +24,31 @@ describe('Calculator', function () {
     fc.startRace();
   });
 
+  it('should confirm the car saw the Chequered Flag', function () {
+    var fc = new $ByLap.FuelCalculatorByLap(fuelTankAttributes, raceParameters, {}, undefined);
+    var raceResult = fc.startRace();
+    expect(raceResult.chequeredFlag).toBe(true);
+  });
+
+  it('should run out of Fuel and not complete the race if using a dogy PitStopStrategy', function () {
+    raceParameters.pitStopStrategy = {
+      shouldPit: function (lapData) {
+        return false;
+      }
+    };
+    var fc = new $ByLap.FuelCalculatorByLap(fuelTankAttributes, raceParameters, {}, undefined);
+    var raceResult = fc.startRace();
+    expect(raceResult.chequeredFlag).toBe(false);
+    expect(raceResult.lapsCompleted).toBe(14); // we make 15 laps with this consumption before it gives up on lap 16
+  });
+
+  it('should return Race Result showing all the laps Completed', function () {
+    fuelTankAttributes = {maximumFuel: 9, initialFuel: 1, minimumFuel:0, consumption:  0.605};
+    var fc = new $ByLap.FuelCalculatorByLap(fuelTankAttributes, raceParameters, {}, undefined);
+    var raceResult = fc.startRace();
+    expect(raceResult.lapsCompleted).toBe(20);
+  });
+
   it('should compute correct number of laps', function () {
     var lapDataHandler = {};
     lapDataHandler.handleData = jasmine.createSpy("handleData");

--- a/test/fuelCalculatorByLaps.test.js
+++ b/test/fuelCalculatorByLaps.test.js
@@ -91,7 +91,7 @@ describe('Calculator', function () {
       this.fuelAdded = pitStopData.fuelAdded;
       this.numPitstops++;
     }
-    var fc = new $ByLap.FuelCalculatorByLap({maximumFuel: 5, minimumFuel:0.3, consumption: 1}, 5, undefined, pitStopHandler);
+    var fc = new $ByLap.FuelCalculatorByLap({maximumFuel: 5, minimumFuel:0.3, consumption: 1}, 5, pitStopParameters, undefined, pitStopHandler);
     fc.startRace();
     expect(pitStopHandler.numPitstops).toBe(1);
   });

--- a/test/fuelCalculatorByLaps.test.js
+++ b/test/fuelCalculatorByLaps.test.js
@@ -3,31 +3,31 @@
 describe('Calculator', function () {
   var $ByLap;
   var fuelTankAttributes;
-  var expectedLaps = 20;
-  var pitStopParameters = {expectedLapTime:107, pitStopTimePenalty:0};
+  var raceParameters;
 
   beforeEach(module("FuelCalculators"));
 
   beforeEach(inject(function (_ByLap_) {
     $ByLap = _ByLap_;
     fuelTankAttributes = {maximumFuel: 9, initialFuel: 9, minimumFuel:0, consumption:  0.605};
+    raceParameters = {numLaps: 20, expectedLapTime:107, pitStopTimePenalty:0};
   }));
 
   it('should handle no lapDapHandler correctly', function () {
 
-    var fc = new $ByLap.FuelCalculatorByLap(fuelTankAttributes, expectedLaps, pitStopParameters, undefined, {});
+    var fc = new $ByLap.FuelCalculatorByLap(fuelTankAttributes, raceParameters, undefined, {});
     fc.startRace();
   });
 
   it('should handle no pitStopHandler correctly', function () {
-    var fc = new $ByLap.FuelCalculatorByLap(fuelTankAttributes, expectedLaps, pitStopParameters, {}, undefined);
+    var fc = new $ByLap.FuelCalculatorByLap(fuelTankAttributes, raceParameters, {}, undefined);
     fc.startRace();
   });
 
   it('should compute correct number of laps', function () {
     var lapDataHandler = {};
     lapDataHandler.handleData = jasmine.createSpy("handleData");
-    var fc = new $ByLap.FuelCalculatorByLap(fuelTankAttributes, expectedLaps, pitStopParameters, lapDataHandler, undefined);
+    var fc = new $ByLap.FuelCalculatorByLap(fuelTankAttributes, raceParameters, lapDataHandler, undefined);
     fc.startRace();
     expect(lapDataHandler.handleData.calls.count()).toBe(21);
   });
@@ -36,7 +36,7 @@ describe('Calculator', function () {
     var pitStopHandler = {};
     pitStopHandler.handlePitStop = jasmine.createSpy("handlePitStop");
     var fuelTankAttributes = {maximumFuel: 9, initialFuel: 9, minimumFuel: 0, consumption:  2};
-    var fc = new $ByLap.FuelCalculatorByLap(fuelTankAttributes, expectedLaps, pitStopParameters, undefined, pitStopHandler);
+    var fc = new $ByLap.FuelCalculatorByLap(fuelTankAttributes, raceParameters, undefined, pitStopHandler);
     fc.startRace();
     expect(pitStopHandler.handlePitStop.calls.count()).toBe(4);
   });
@@ -44,7 +44,7 @@ describe('Calculator', function () {
   it('Pitstop event should indicate how much fuel was put in', function () {
     var pitStopHandler = {};
     pitStopHandler.handlePitStop = jasmine.createSpy("handlePitStop");
-    var fc = new $ByLap.FuelCalculatorByLap({maximumFuel: 10, minimumFuel:0, consumption:2}, 10, pitStopParameters, undefined, pitStopHandler);
+    var fc = new $ByLap.FuelCalculatorByLap({maximumFuel: 10, minimumFuel:0, consumption:2}, raceParameters, undefined, pitStopHandler);
     fc.startRace();
     expect(pitStopHandler.handlePitStop.calls.first()).toEqual({object: pitStopHandler, args: [{lapNumber:5, fuelState:0, fuelAdded:10, fuelStateOnExit:10}], returnValue: undefined});
 
@@ -53,15 +53,17 @@ describe('Calculator', function () {
   it('should not run any laps with 0 fuel tank consumption', function () {
     var lapDataHandler = {};
     lapDataHandler.handleData = jasmine.createSpy("handleData");
-    var fc = new $ByLap.FuelCalculatorByLap(fuelTankAttributes, expectedLaps, 0, pitStopParameters, lapDataHandler, undefined);
+    fuelTankAttributes.consumption=0;
+    var fc = new $ByLap.FuelCalculatorByLap(fuelTankAttributes, raceParameters, lapDataHandler, undefined);
     fc.startRace();
     expect(lapDataHandler.handleData.calls.count()).toBe(0);
   });
 
-  it('should not run any laps with 0 expectedLaps', function () {
+  it('should not run any laps with 0 numLaps', function () {
     var lapDataHandler = {};
     lapDataHandler.handleData = jasmine.createSpy("handleData");
-    var fc = new $ByLap.FuelCalculatorByLap(fuelTankAttributes, 0, pitStopParameters, lapDataHandler, undefined);
+    raceParameters.numLaps = 0;
+    var fc = new $ByLap.FuelCalculatorByLap(fuelTankAttributes,  raceParameters, lapDataHandler, undefined);
     fc.startRace();
     expect(lapDataHandler.handleData.calls.count()).toBe(0);
   });
@@ -69,7 +71,7 @@ describe('Calculator', function () {
   it('should not suggest to pit on the final lap...', function () {
     var pitStopHandler = {};
     pitStopHandler.handlePitStop = jasmine.createSpy("handlePitStop");
-    var fc = new $ByLap.FuelCalculatorByLap({maximumFuel: 9.7, consumption: 0.605}, 16, pitStopParameters, undefined, pitStopHandler);
+    var fc = new $ByLap.FuelCalculatorByLap({maximumFuel: 9.7, consumption: 0.605}, raceParameters, undefined, pitStopHandler);
     fc.startRace();
     expect(pitStopHandler.handlePitStop.calls.count()).toBe(0);
   });
@@ -80,7 +82,7 @@ describe('Calculator', function () {
       this.fuelAdded = pitStopData.fuelAdded;
       this.numPitstops++;
     }
-    var fc = new $ByLap.FuelCalculatorByLap({maximumFuel: 9.7, consumption: 0.605}, 16, pitStopParameters, undefined, pitStopHandler);
+    var fc = new $ByLap.FuelCalculatorByLap({maximumFuel: 9.7, consumption: 0.605}, raceParameters, undefined, pitStopHandler);
     fc.startRace();
     expect(pitStopHandler.numPitstops).toBe(0);
   });
@@ -90,8 +92,9 @@ describe('Calculator', function () {
     pitStopHandler.handlePitStop = function (pitStopData) {
       this.fuelAdded = pitStopData.fuelAdded;
       this.numPitstops++;
-    }
-    var fc = new $ByLap.FuelCalculatorByLap({maximumFuel: 5, minimumFuel:0.3, consumption: 1}, 5, pitStopParameters, undefined, pitStopHandler);
+    };
+    raceParameters.numLaps = 5;
+    var fc = new $ByLap.FuelCalculatorByLap({maximumFuel: 5, minimumFuel:0.3, consumption: 1}, raceParameters, undefined, pitStopHandler);
     fc.startRace();
     expect(pitStopHandler.numPitstops).toBe(1);
   });

--- a/test/pitstop-strategy.test.js
+++ b/test/pitstop-strategy.test.js
@@ -9,7 +9,7 @@ describe('Pitstop Strategy', function () {
 
   beforeEach(inject(function (_ByLap_) {
     $ByLap = _ByLap_;
-    fuelTankAttributes = {maximumFuel: 9, initialFuel: 9, consumption: 1};
+    fuelTankAttributes = {maximumFuel: 9, initialFuel: 9, minimumFuel:0, consumption: 1};
   }));
 
 

--- a/test/pitstop-strategy.test.js
+++ b/test/pitstop-strategy.test.js
@@ -16,7 +16,8 @@ describe('Pitstop Strategy', function () {
 
   it('should calculate expected race time with no pitstops', function () {
     var fc = new $ByLap.FuelCalculatorByLap(fuelTankAttributes, raceParameters);
-    fc.startRace();
+    var raceResult = fc.startRace();
+    expect(raceResult.chequeredFlag).toBe(true);
     expect(fc.totalRaceTime()).toBe(900);
   });
 

--- a/test/pitstop-strategy.test.js
+++ b/test/pitstop-strategy.test.js
@@ -4,58 +4,58 @@ describe('Pitstop Strategy', function () {
   var $ByLap;
   var fuelTankAttributes;
   var raceParameters;
-  var expectedLaps = 20;
 
   beforeEach(module("FuelCalculators"));
 
   beforeEach(inject(function (_ByLap_) {
     $ByLap = _ByLap_;
     fuelTankAttributes = {maximumFuel: 9, initialFuel: 9, minimumFuel:0, consumption: 1};
-    raceParameters = {expectedLapTime:100, pitStopTimePenalty:60};
+    raceParameters = {numLaps: 9, expectedLapTime:100, pitStopTimePenalty:60};
   }));
 
 
   it('should calculate expected race time with no pitstops', function () {
-    var fc = new $ByLap.FuelCalculatorByLap(fuelTankAttributes, 9, raceParameters);
+    var fc = new $ByLap.FuelCalculatorByLap(fuelTankAttributes, raceParameters);
     fc.startRace();
     expect(fc.totalRaceTime()).toBe(900);
   });
 
   it('should calculate expected race time with 1 pitstops', function () {
     fuelTankAttributes.consumption = 1.5; // increase fuel consumption so that it forces at least 1 pitstop
-    var fc = new $ByLap.FuelCalculatorByLap(fuelTankAttributes, 9, raceParameters);
+    var fc = new $ByLap.FuelCalculatorByLap(fuelTankAttributes, raceParameters);
     fc.startRace();
     expect(fc.totalRaceTime()).toBe(960);
   });
 
   it('should calculate expected race time with 2 pitstops', function () {
     fuelTankAttributes.consumption = 3; // increase fuel consumption so that it forces at least 1 pitstop
-    var fc = new $ByLap.FuelCalculatorByLap(fuelTankAttributes, 9, raceParameters);
+    var fc = new $ByLap.FuelCalculatorByLap(fuelTankAttributes, raceParameters);
     fc.startRace();
     expect(fc.totalRaceTime()).toBe(1020); // 900 + 3 pitstops
   });
 
   it('should calculate expected race time with initial Fuel', function () {
     fuelTankAttributes.initialFuel = 3; // start off with a smaller tank which forces a pitstop
-    var fc = new $ByLap.FuelCalculatorByLap(fuelTankAttributes, 9, raceParameters);
+    var fc = new $ByLap.FuelCalculatorByLap(fuelTankAttributes, raceParameters);
     fc.startRace();
     expect(fc.totalRaceTime()).toBe(960); // 900 + 3 pitstops
   });
 
   it('should not be a valid Race if there is no fuel in the tank', function () {
     fuelTankAttributes.initialFuel = 0; // start off with a smaller tank which forces a pitstop
-    var fc = new $ByLap.FuelCalculatorByLap(fuelTankAttributes, 9, raceParameters);
+    var fc = new $ByLap.FuelCalculatorByLap(fuelTankAttributes, raceParameters);
     expect(fc.canStartRace()).toBe(false);
   });
 
   it('should not be a valid Race if the car consumes no fuel', function () {
     fuelTankAttributes.consumption = 0;
-    var fc = new $ByLap.FuelCalculatorByLap(fuelTankAttributes, 9, raceParameters);
+    var fc = new $ByLap.FuelCalculatorByLap(fuelTankAttributes, raceParameters);
     expect(fc.canStartRace()).toBe(false);
   });
 
   it('should not be a valid Race if there are no laps', function () {
-    var fc = new $ByLap.FuelCalculatorByLap(fuelTankAttributes, 0, raceParameters);
+    raceParameters.numLaps=0;
+    var fc = new $ByLap.FuelCalculatorByLap(fuelTankAttributes, raceParameters);
     expect(fc.canStartRace()).toBe(false);
   });
 

--- a/test/pitstop-strategy.test.js
+++ b/test/pitstop-strategy.test.js
@@ -18,28 +18,28 @@ describe('Pitstop Strategy', function () {
     var fc = new $ByLap.FuelCalculatorByLap(fuelTankAttributes, raceParameters);
     var raceResult = fc.startRace();
     expect(raceResult.chequeredFlag).toBe(true);
-    expect(fc.totalRaceTime()).toBe(900);
+    expect(raceResult.totalRaceTime).toBe(900);
   });
 
   it('should calculate expected race time with 1 pitstops', function () {
     fuelTankAttributes.consumption = 1.5; // increase fuel consumption so that it forces at least 1 pitstop
     var fc = new $ByLap.FuelCalculatorByLap(fuelTankAttributes, raceParameters);
-    fc.startRace();
-    expect(fc.totalRaceTime()).toBe(960);
+    var raceResult = fc.startRace();
+    expect(raceResult.totalRaceTime).toBe(960);
   });
 
   it('should calculate expected race time with 2 pitstops', function () {
     fuelTankAttributes.consumption = 3; // increase fuel consumption so that it forces at least 1 pitstop
     var fc = new $ByLap.FuelCalculatorByLap(fuelTankAttributes, raceParameters);
-    fc.startRace();
-    expect(fc.totalRaceTime()).toBe(1020); // 900 + 3 pitstops
+    var raceResult = fc.startRace();
+    expect(raceResult.totalRaceTime).toBe(1020); // 900 + 3 pitstops
   });
 
   it('should calculate expected race time with initial Fuel', function () {
     fuelTankAttributes.initialFuel = 3; // start off with a smaller tank which forces a pitstop
     var fc = new $ByLap.FuelCalculatorByLap(fuelTankAttributes, raceParameters);
-    fc.startRace();
-    expect(fc.totalRaceTime()).toBe(960); // 900 + 3 pitstops
+    var raceResult = fc.startRace();
+    expect(raceResult.totalRaceTime).toBe(960); // 900 + 3 pitstops
   });
 
   it('should not be a valid Race if there is no fuel in the tank', function () {

--- a/test/pitstop-strategy.test.js
+++ b/test/pitstop-strategy.test.js
@@ -44,6 +44,22 @@ describe('Pitstop Strategy', function () {
     expect(fc.totalRaceTime()).toBe(960); // 900 + 3 pitstops
   });
 
+  it('should not be a valid Race if there is no fuel in the tank', function () {
+    var raceParameters = {expectedLapTime:100, pitStopTimePenalty:60};
+    fuelTankAttributes.initialFuel = 0; // start off with a smaller tank which forces a pitstop
+    var fc = new $ByLap.FuelCalculatorByLap(fuelTankAttributes, 9, raceParameters);
+    expect(fc.canStartRace()).toBe(false);
+  });
+
+  it('should not be a valid Race if the car consumes no fuel', function () {
+    var raceParameters = {expectedLapTime:100, pitStopTimePenalty:60};
+    fuelTankAttributes.consumption = 0;
+    var fc = new $ByLap.FuelCalculatorByLap(fuelTankAttributes, 9, raceParameters);
+    expect(fc.canStartRace()).toBe(false);
+  });
+
+
+
 
 
 });

--- a/test/pitstop-strategy.test.js
+++ b/test/pitstop-strategy.test.js
@@ -58,6 +58,12 @@ describe('Pitstop Strategy', function () {
     expect(fc.canStartRace()).toBe(false);
   });
 
+  it('should not be a valid Race if there are no laps', function () {
+    var raceParameters = {expectedLapTime:100, pitStopTimePenalty:60};
+    var fc = new $ByLap.FuelCalculatorByLap(fuelTankAttributes, 0, raceParameters);
+    expect(fc.canStartRace()).toBe(false);
+  });
+
 
 
 

--- a/test/pitstop-strategy.test.js
+++ b/test/pitstop-strategy.test.js
@@ -1,0 +1,49 @@
+"use strict"
+
+describe('Pitstop Strategy', function () {
+  var $ByLap;
+  var fuelTankAttributes;
+  var expectedLaps = 20;
+
+  beforeEach(module("FuelCalculators"));
+
+  beforeEach(inject(function (_ByLap_) {
+    $ByLap = _ByLap_;
+    fuelTankAttributes = {maximumFuel: 9, initialFuel: 9, consumption: 1};
+  }));
+
+
+  it('should calculate expected race time with no pitstops', function () {
+    var raceParameters = {expectedLapTime:100, pitStopTimePenalty:60};
+    var fc = new $ByLap.FuelCalculatorByLap(fuelTankAttributes, 9, raceParameters);
+    fc.startRace();
+    expect(fc.totalRaceTime()).toBe(900);
+  });
+
+  it('should calculate expected race time with 1 pitstops', function () {
+    var raceParameters = {expectedLapTime:100, pitStopTimePenalty:60};
+    fuelTankAttributes.consumption = 1.5; // increase fuel consumption so that it forces at least 1 pitstop
+    var fc = new $ByLap.FuelCalculatorByLap(fuelTankAttributes, 9, raceParameters);
+    fc.startRace();
+    expect(fc.totalRaceTime()).toBe(960);
+  });
+
+  it('should calculate expected race time with 2 pitstops', function () {
+    var raceParameters = {expectedLapTime:100, pitStopTimePenalty:60};
+    fuelTankAttributes.consumption = 3; // increase fuel consumption so that it forces at least 1 pitstop
+    var fc = new $ByLap.FuelCalculatorByLap(fuelTankAttributes, 9, raceParameters);
+    fc.startRace();
+    expect(fc.totalRaceTime()).toBe(1020); // 900 + 3 pitstops
+  });
+
+  it('should calculate expected race time with initial Fuel', function () {
+    var raceParameters = {expectedLapTime:100, pitStopTimePenalty:60};
+    fuelTankAttributes.initialFuel = 3; // start off with a smaller tank which forces a pitstop
+    var fc = new $ByLap.FuelCalculatorByLap(fuelTankAttributes, 9, raceParameters);
+    fc.startRace();
+    expect(fc.totalRaceTime()).toBe(960); // 900 + 3 pitstops
+  });
+
+
+
+});

--- a/test/pitstop-strategy.test.js
+++ b/test/pitstop-strategy.test.js
@@ -3,6 +3,7 @@
 describe('Pitstop Strategy', function () {
   var $ByLap;
   var fuelTankAttributes;
+  var raceParameters;
   var expectedLaps = 20;
 
   beforeEach(module("FuelCalculators"));
@@ -10,18 +11,17 @@ describe('Pitstop Strategy', function () {
   beforeEach(inject(function (_ByLap_) {
     $ByLap = _ByLap_;
     fuelTankAttributes = {maximumFuel: 9, initialFuel: 9, minimumFuel:0, consumption: 1};
+    raceParameters = {expectedLapTime:100, pitStopTimePenalty:60};
   }));
 
 
   it('should calculate expected race time with no pitstops', function () {
-    var raceParameters = {expectedLapTime:100, pitStopTimePenalty:60};
     var fc = new $ByLap.FuelCalculatorByLap(fuelTankAttributes, 9, raceParameters);
     fc.startRace();
     expect(fc.totalRaceTime()).toBe(900);
   });
 
   it('should calculate expected race time with 1 pitstops', function () {
-    var raceParameters = {expectedLapTime:100, pitStopTimePenalty:60};
     fuelTankAttributes.consumption = 1.5; // increase fuel consumption so that it forces at least 1 pitstop
     var fc = new $ByLap.FuelCalculatorByLap(fuelTankAttributes, 9, raceParameters);
     fc.startRace();
@@ -29,7 +29,6 @@ describe('Pitstop Strategy', function () {
   });
 
   it('should calculate expected race time with 2 pitstops', function () {
-    var raceParameters = {expectedLapTime:100, pitStopTimePenalty:60};
     fuelTankAttributes.consumption = 3; // increase fuel consumption so that it forces at least 1 pitstop
     var fc = new $ByLap.FuelCalculatorByLap(fuelTankAttributes, 9, raceParameters);
     fc.startRace();
@@ -37,7 +36,6 @@ describe('Pitstop Strategy', function () {
   });
 
   it('should calculate expected race time with initial Fuel', function () {
-    var raceParameters = {expectedLapTime:100, pitStopTimePenalty:60};
     fuelTankAttributes.initialFuel = 3; // start off with a smaller tank which forces a pitstop
     var fc = new $ByLap.FuelCalculatorByLap(fuelTankAttributes, 9, raceParameters);
     fc.startRace();
@@ -45,27 +43,20 @@ describe('Pitstop Strategy', function () {
   });
 
   it('should not be a valid Race if there is no fuel in the tank', function () {
-    var raceParameters = {expectedLapTime:100, pitStopTimePenalty:60};
     fuelTankAttributes.initialFuel = 0; // start off with a smaller tank which forces a pitstop
     var fc = new $ByLap.FuelCalculatorByLap(fuelTankAttributes, 9, raceParameters);
     expect(fc.canStartRace()).toBe(false);
   });
 
   it('should not be a valid Race if the car consumes no fuel', function () {
-    var raceParameters = {expectedLapTime:100, pitStopTimePenalty:60};
     fuelTankAttributes.consumption = 0;
     var fc = new $ByLap.FuelCalculatorByLap(fuelTankAttributes, 9, raceParameters);
     expect(fc.canStartRace()).toBe(false);
   });
 
   it('should not be a valid Race if there are no laps', function () {
-    var raceParameters = {expectedLapTime:100, pitStopTimePenalty:60};
     var fc = new $ByLap.FuelCalculatorByLap(fuelTankAttributes, 0, raceParameters);
     expect(fc.canStartRace()).toBe(false);
   });
-
-
-
-
 
 });


### PR DESCRIPTION
Initial work to start to include the penalty induced by taking a pitstop into a race time calculation that will be used in the future as part of comparing different strategies.  

Obviously doing 0 pitstops is faster than doing 1 if there's enough fuel in the tank..  And 1 pit stop might be better than 2, once we start to include fuel weight penalty into the calculations (in the future).

The future genetic algorithm modeling will use the projected Race Time including any pitstop penalty as part of the Fitness calculation - a faster race time is a better strategy !

I have another branch that is starting the genetic-js scaffolding that is based on this branch.